### PR TITLE
Create separate `walk_node`s

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main_loop(int num_steps, int iters, bool naive, int seed, bool require_succe
               const std::string &out_dir) {
   pivot::walk_base<Dim> *w;
   if (!naive) {
-    w = pivot::walk_tree<Dim>::line(num_steps);
+    w = pivot::walk_node<Dim>::line(num_steps);
   } else {
     w = new pivot::walk<Dim>(num_steps);
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,7 +11,7 @@ int main_loop(int num_steps, int iters, bool naive, int seed, bool require_succe
               const std::string &out_dir) {
   pivot::walk_base<Dim> *w;
   if (!naive) {
-    w = pivot::walk_node<Dim>::line(num_steps);
+    w = new pivot::walk_tree<Dim>(num_steps);
   } else {
     w = new pivot::walk<Dim>(num_steps);
   }

--- a/src/walk.h
+++ b/src/walk.h
@@ -55,7 +55,7 @@ public:
   bool rand_pivot() override {
     auto [step, new_points] = try_rand_pivot();
     if (!new_points) {
-      return false; // NOLINT(clang-analyzer-cplusplus.NewDeleteLeaks)
+      return false;
     }
     do_pivot(step, new_points.value());
     return true;

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -16,7 +16,7 @@ TEST(IntTest, Walk) {
 }
 
 TEST(IntTest, WalkTree) {
-  walk_tree<2> *w = walk_tree<2>::line(2);
+  walk_node<2> *w = walk_node<2>::line(2);
   for (int i = 0; i < 10; ++i) {
     for (int j = 0; j < 100; j++) {
       w->rand_pivot();

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -16,12 +16,11 @@ TEST(IntTest, Walk) {
 }
 
 TEST(IntTest, WalkTree) {
-  walk_node<2> *w = walk_node<2>::line(2);
+  auto w = walk_tree<2>(2);
   for (int i = 0; i < 10; ++i) {
     for (int j = 0; j < 100; j++) {
-      w->rand_pivot();
+      w.rand_pivot();
     }
-    EXPECT_TRUE(w->self_avoiding());
+    EXPECT_TRUE(w.self_avoiding());
   }
-  delete w;
 }

--- a/tests/walk_tree_test.cpp
+++ b/tests/walk_tree_test.cpp
@@ -5,7 +5,7 @@
 using namespace pivot;
 
 TEST(WalkTreeInit, Line) {
-    walk_tree<2> *w = walk_tree<2>::line(5);
+    walk_node<2> *w = walk_node<2>::line(5);
     ASSERT_TRUE(w->self_avoiding());
     auto steps = w->steps();
     EXPECT_EQ(steps.size(), 5);
@@ -18,7 +18,7 @@ TEST(WalkTreeInit, Line) {
 }
 
 TEST(WalkTreePivot, PivotLine) {
-    walk_tree<2> *w = walk_tree<2>::line(2);
+    walk_node<2> *w = walk_node<2>::line(2);
     pivot::transform<2> trans = transform<2>({1, 0}, {-1, 1});
     EXPECT_TRUE(w->try_pivot(1, trans));
     auto steps = w->steps();
@@ -29,7 +29,7 @@ TEST(WalkTreePivot, PivotLine) {
 }
 
 TEST(WalkTreePivot, PivotLineFail) {
-    walk_tree<2> *w = walk_tree<2>::line(3);
+    walk_node<2> *w = walk_node<2>::line(3);
     pivot::transform<2> trans = transform<2>({0, 1}, {-1, 1});
     EXPECT_FALSE(w->try_pivot(2, trans));
     auto steps = w->steps();

--- a/tests/walk_tree_test.cpp
+++ b/tests/walk_tree_test.cpp
@@ -5,37 +5,34 @@
 using namespace pivot;
 
 TEST(WalkTreeInit, Line) {
-    walk_node<2> *w = walk_node<2>::line(5);
-    ASSERT_TRUE(w->self_avoiding());
-    auto steps = w->steps();
+    auto w = walk_tree<2>(5);
+    ASSERT_TRUE(w.self_avoiding());
+    auto steps = w.steps();
     EXPECT_EQ(steps.size(), 5);
     for (int i = 0; i < 5; i++) {
         EXPECT_EQ(steps[i], pivot::point<2>({i + 1, 0}));
     }
-    EXPECT_FALSE(w->is_leaf());
-    EXPECT_EQ(w->endpoint(), pivot::point<2>({5, 0}));
-    delete w;
+    EXPECT_FALSE(w.is_leaf());
+    EXPECT_EQ(w.endpoint(), pivot::point<2>({5, 0}));
 }
 
 TEST(WalkTreePivot, PivotLine) {
-    walk_node<2> *w = walk_node<2>::line(2);
+    auto w = walk_tree<2>(2);
     pivot::transform<2> trans = transform<2>({1, 0}, {-1, 1});
-    EXPECT_TRUE(w->try_pivot(1, trans));
-    auto steps = w->steps();
+    EXPECT_TRUE(w.try_pivot(1, trans));
+    auto steps = w.steps();
     EXPECT_EQ(steps.size(), 2);
     EXPECT_EQ(steps[0], pivot::point<2>({1, 0}));
     EXPECT_EQ(steps[1], pivot::point<2>({1, 1}));
-    delete w;
 }
 
 TEST(WalkTreePivot, PivotLineFail) {
-    walk_node<2> *w = walk_node<2>::line(3);
+    auto w = walk_tree<2>(3);
     pivot::transform<2> trans = transform<2>({0, 1}, {-1, 1});
-    EXPECT_FALSE(w->try_pivot(2, trans));
-    auto steps = w->steps();
+    EXPECT_FALSE(w.try_pivot(2, trans));
+    auto steps = w.steps();
     EXPECT_EQ(steps.size(), 3);
     EXPECT_EQ(steps[0], pivot::point<2>({1, 0}));
     EXPECT_EQ(steps[1], pivot::point<2>({2, 0}));
     EXPECT_EQ(steps[2], pivot::point<2>({3, 0}));
-    delete w;
 }


### PR DESCRIPTION
Splits `walk_tree` into `walk_node` and `walk_tree`, exposing the latter to the client.