### PR TITLE
Fix balanced representation of walk_tree

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -100,6 +100,14 @@ public:
     return point(coords);
   }
 
+  int norm() const {
+    int sum = 0;
+    for (int i = 0; i < Dim; ++i) {
+      sum += coords_[i] * coords_[i];
+    }
+    return sum;
+  }
+
   /** @brief Returns the string of the form "({coords_[0]}, ..., {coords_[Dim - 1]})" */
   std::string to_string() const {
     std::string s = "(";

--- a/src/walk_node.h
+++ b/src/walk_node.h
@@ -70,9 +70,17 @@ public:
     }
   }
 
-  bool is_leaf() const { return left_ == nullptr && right_ == nullptr; }
+  const box<Dim> &bbox() const { return bbox_; }
 
-  point<Dim> endpoint() const { return end_; }
+  const point<Dim> &endpoint() const { return end_; }
+
+  const transform<Dim> &symm() const { return symm_; }
+
+  walk_node *left() const { return left_; }
+
+  walk_node *right() const { return right_; }
+
+  bool is_leaf() const { return left_ == nullptr && right_ == nullptr; }
 
   std::vector<point<Dim>> steps() const {
     std::vector<point<Dim>> result;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,7 +12,7 @@ enable_testing()
 
 include(GoogleTest)
 
-add_executable(test_pivot int_test.cpp utils_test.cpp walk_tree_test.cpp)
+add_executable(test_pivot test_utils.h int_test.cpp utils_test.cpp walk_node_test.cpp walk_tree_test.cpp)
 target_include_directories(test_pivot PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(test_pivot pivot GTest::gtest_main)
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+
+#include "utils.h"
+
+using namespace pivot;
+
+template <int Dim>
+std::vector<pivot::point<Dim>> random_walk(int num_sites) {
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    static std::uniform_int_distribution<> dist(0, Dim - 1);
+
+    std::vector<pivot::point<Dim>> steps;
+    steps.push_back(pivot::point<Dim>::unit(0));
+    for (int i = 1; i < num_sites; ++i) {
+        steps.push_back(steps.back() + pivot::point<Dim>::unit(dist(gen)));
+    }
+    return steps;
+}
+
+template <int Dim>
+std::vector<pivot::point<Dim>> set_start(const pivot::point<Dim> &start, const std::vector<pivot::point<Dim>> &steps) {
+    std::vector<pivot::point<Dim>> shifted;
+    for (const auto &step : steps) {
+        shifted.push_back(step - steps[0] + start);
+    }
+    return shifted;
+}

--- a/tests/walk_node_test.cpp
+++ b/tests/walk_node_test.cpp
@@ -1,0 +1,104 @@
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "walk_tree.h"
+
+#include "test_utils.h"
+
+using namespace pivot;
+
+TEST(WalkNode, Balanced1) {
+    auto steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({2, 1}), pivot::point<2>({3, 1})};
+    auto root = walk_node<2>::balanced_rep(steps);
+
+    auto symm = root->symm();
+    auto end = root->endpoint();
+    auto b = root->bbox();
+    auto expect_box = pivot::box<2>(std::array{interval{1, 3}, interval{0, 1}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {-1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({3, 1}));
+    EXPECT_EQ(b, expect_box);
+
+    auto left = root->left();
+    symm = left->symm();
+    end = left->endpoint();
+    b = left->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({2, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto right  = root->right();
+    symm = right->symm();
+    end = right->endpoint();
+    b = right->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {1, -1}));
+    EXPECT_EQ(end, pivot::point<2>({1, -1}));
+    EXPECT_EQ(b, expect_box);
+
+    EXPECT_TRUE(left->left()->is_leaf());
+    EXPECT_TRUE(left->right()->is_leaf());
+    EXPECT_TRUE(right->left()->is_leaf());
+    EXPECT_TRUE(right->right()->is_leaf());
+
+    delete root;
+}
+
+TEST(WalkNode, Balanced2) {
+    // steps and tree from Clisby (2010), Figs. 1, 23
+    auto steps = {pivot::point<2>({1, 0}), pivot::point<2>({1, 1}), pivot::point<2>({2, 1}), pivot::point<2>({3, 1}),
+                  pivot::point<2>({3, 0})};
+    auto root = walk_node<2>::balanced_rep(steps);
+
+    auto symm = root->symm();
+    auto end = root->endpoint();
+    auto b = root->bbox();
+    auto expect_box = pivot::box<2>(std::array{interval{1, 3}, interval{0, 1}});
+    EXPECT_EQ(symm, transform<2>({0, 1}, {1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({3, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto left = root->left();
+    symm = left->symm();
+    end = left->endpoint();
+    b = left->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 1}});
+    EXPECT_EQ(symm, transform<2>({0, 1}, {1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({2, 1}));
+    EXPECT_EQ(b, expect_box);
+
+    auto right  = root->right();
+    symm = right->symm();
+    end = right->endpoint();
+    b = right->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 1}, interval{-1, 0}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {1, -1}));
+    EXPECT_EQ(end, pivot::point<2>({1, -1}));
+    EXPECT_EQ(b, expect_box);
+
+    symm = left->left()->symm();
+    end = left->left()->endpoint();
+    b = left->left()->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 1}, interval{0, 1}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {-1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({1, 1}));
+    EXPECT_EQ(b, expect_box);
+
+    EXPECT_TRUE(left->right()->is_leaf());
+    EXPECT_TRUE(right->left()->is_leaf());
+    EXPECT_TRUE(right->right()->is_leaf());
+    EXPECT_TRUE(left->left()->left()->is_leaf());
+    EXPECT_TRUE(left->left()->right()->is_leaf());
+
+    delete root;
+}
+
+TEST(WalkNode, BalancedSteps) {
+    auto steps = random_walk<2>(100);
+    auto root = walk_node<2>::balanced_rep(steps);
+    auto result = root->steps();
+    EXPECT_EQ(steps, result);
+    delete root;
+}


### PR DESCRIPTION
Previous implementation failed to account for accumulated "global" symmetries in sub-trees. This didn't affect previous runs because walks were always initialized as lines, which weren't affected by this problem.