### PR TITLE
Fix sub-tree bounding boxes in balanced representation

### DIFF
--- a/src/walk_node.h
+++ b/src/walk_node.h
@@ -87,6 +87,14 @@ public:
 
   walk_node *right() const { return right_; }
 
+  bool operator==(const walk_node &other) const {
+    if (is_leaf() && other.is_leaf()) {
+      return true;
+    }
+    return id_ == other.id_ && num_sites_ == other.num_sites_ && symm_ == other.symm_ && bbox_ == other.bbox_ &&
+           end_ == other.end_ && *left_ == *other.left_ && *right_ == *other.right_;
+  }
+
   bool is_leaf() const { return left_ == nullptr && right_ == nullptr; }
 
   std::vector<point<Dim>> steps() const {

--- a/src/walk_node.h
+++ b/src/walk_node.h
@@ -254,7 +254,8 @@ private:
     auto glob_inv = glob_symm.inverse();
     auto rel_symm = glob_inv * abs_symm;
     auto rel_end = glob_inv * (steps.back() - steps.front()) + pivot::point<Dim>::unit(0);
-    walk_node *root = new walk_node(start + n - 1, num_sites, rel_symm, box(steps), rel_end);
+    auto rel_box = point<Dim>::unit(0) + glob_inv * (point<Dim>() - point<Dim>::unit(0) + box(steps));
+    walk_node *root = new walk_node(start + n - 1, num_sites, rel_symm, rel_box, rel_end);
 
     if (n >= 1) {
       root->left_ = balanced_rep(steps.subspan(0, n), start, glob_symm);

--- a/src/walk_node.h
+++ b/src/walk_node.h
@@ -125,7 +125,7 @@ public:
     gvc.gvFreeContext(context);
   }
 
-  void rotate_left() {
+  walk_node *rotate_left() {
     if (right_->is_leaf()) {
       throw std::invalid_argument("can't rotate left on a leaf node");
     }
@@ -149,9 +149,11 @@ public:
     int temp_id = id_;
     id_ = left_->id_;
     left_->id_ = temp_id;
+
+    return this;
   }
 
-  void rotate_right() {
+  walk_node *rotate_right() {
     if (left_->is_leaf()) {
       throw std::invalid_argument("can't rotate right on a leaf node");
     }
@@ -175,9 +177,11 @@ public:
     int temp_id = id_;
     id_ = right_->id_;
     right_->id_ = temp_id;
+
+    return this;
   }
 
-  void shuffle_up(int id) {
+  walk_node *shuffle_up(int id) {
     if (id < left_->num_sites_) {
       left_->shuffle_up(id);
       rotate_right();
@@ -185,9 +189,11 @@ public:
       right_->shuffle_up(id - left_->num_sites_);
       rotate_left();
     }
+
+    return this;
   }
 
-  void shuffle_down() {
+  walk_node *shuffle_down() {
     int id = std::floor((num_sites_ + 1) / 2.0);
     if (id < left_->num_sites_) {
       rotate_right();
@@ -196,6 +202,8 @@ public:
       rotate_left();
       left_->shuffle_down();
     }
+
+    return this;
   }
 
   bool intersect() const {

--- a/tests/walk_node_test.cpp
+++ b/tests/walk_node_test.cpp
@@ -33,10 +33,10 @@ TEST(WalkNode, Balanced1) {
     symm = right->symm();
     end = right->endpoint();
     b = right->bbox();
-    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    expect_box = pivot::box<2>(std::array{interval{1, 1}, interval{-1, 0}});
     EXPECT_EQ(symm, transform<2>({1, 0}, {1, -1}));
     EXPECT_EQ(end, pivot::point<2>({1, -1}));
-    EXPECT_EQ(b, expect_box);
+    EXPECT_EQ(b, expect_box) << "b: " << b.to_string() << " expect_box: " << expect_box.to_string();
 
     EXPECT_TRUE(left->left()->is_leaf());
     EXPECT_TRUE(left->right()->is_leaf());
@@ -95,10 +95,158 @@ TEST(WalkNode, Balanced2) {
     delete root;
 }
 
+TEST(WalkNode, Balanced3) {
+    std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({2, 1}), pivot::point<2>({2, 2})};
+    auto root = walk_node<2>::balanced_rep(steps);
+
+    auto symm = root->symm();
+    auto end = root->endpoint();
+    auto b = root->bbox();
+    auto expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 2}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {-1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({2, 2}));
+    EXPECT_EQ(b, expect_box);
+
+    auto left = root->left();
+    symm = left->symm();
+    end = left->endpoint();
+    b = left->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({2, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto right  = root->right();
+    symm = right->symm();
+    end = right->endpoint();
+    b = right->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({2, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    EXPECT_TRUE(left->left()->is_leaf());
+    EXPECT_TRUE(left->right()->is_leaf());
+    EXPECT_TRUE(right->left()->is_leaf());
+    EXPECT_TRUE(right->right()->is_leaf());
+
+    delete root;
+}
+
+TEST(RandomWalk, IsNearestNeighbor) {
+    auto steps = random_walk<2>(100);
+    ASSERT_EQ(steps.size(), 100);
+    for (int i = 1; i < 100; ++i) {
+        EXPECT_EQ((steps[i] - steps[i - 1]).norm(), 1);
+    }
+}
+
 TEST(WalkNode, BalancedSteps) {
     auto steps = random_walk<2>(100);
     auto root = walk_node<2>::balanced_rep(steps);
     auto result = root->steps();
     EXPECT_EQ(steps, result);
     delete root;
+}
+
+TEST(WalkNode, RotateRight2D1) {
+    std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({3, 0})};
+    auto root = walk_node<2>::balanced_rep(steps);
+
+    root->rotate_right();
+    auto symm = root->symm();
+    auto end = root->endpoint();
+    auto b = root->bbox();
+    auto expect_box = pivot::box<2>(std::array{interval{1, 3}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({3, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto right = root->right();
+    symm = right->symm();
+    end = right->endpoint();
+    b = right->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({2, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto left = root->left();
+    EXPECT_TRUE(left->is_leaf());
+    EXPECT_TRUE(right->left()->is_leaf());
+    EXPECT_TRUE(right->right()->is_leaf());
+
+    delete root;
+}
+
+TEST(WalkNode, RotateRight2D2) {
+    std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({1, 1}), pivot::point<2>({1, 2})};
+    auto root = walk_node<2>::balanced_rep(steps);
+
+    root->rotate_right();
+    auto symm = root->symm();
+    auto end = root->endpoint();
+    auto b = root->bbox();
+    auto expect_box = pivot::box<2>(std::array{interval{1, 1}, interval{0, 2}});
+    EXPECT_EQ(symm, transform<2>({1, 0}, {-1, 1}));
+    EXPECT_EQ(end, pivot::point<2>({1, 2}));
+    EXPECT_EQ(b, expect_box);
+
+    auto right = root->right();
+    symm = right->symm();
+    end = right->endpoint();
+    b = right->bbox();
+    expect_box = pivot::box<2>(std::array{interval{1, 2}, interval{0, 0}});
+    EXPECT_EQ(symm, transform<2>());
+    EXPECT_EQ(end, pivot::point<2>({2, 0}));
+    EXPECT_EQ(b, expect_box);
+
+    auto left = root->left();
+    EXPECT_TRUE(left->is_leaf());
+    EXPECT_TRUE(right->left()->is_leaf());
+    EXPECT_TRUE(right->right()->is_leaf());
+
+    delete root;
+}
+
+TEST(WalkNode, RotateRightStepsRand2D) {
+    int num_sites = 100;
+    auto steps = random_walk<2>(num_sites);
+
+    auto root = walk_node<2>::balanced_rep(steps);
+    ASSERT_EQ(root->steps(), steps);
+    EXPECT_EQ(root->rotate_right()->steps(), steps);
+    delete root;
+}
+
+TEST(WalkNode, RotateLeftStepsRand2D) {
+    int num_sites = 100;
+    auto steps = random_walk<2>(num_sites);
+
+    auto root = walk_node<2>::balanced_rep(steps);
+    ASSERT_EQ(root->steps(), steps);
+    EXPECT_EQ(root->rotate_left()->steps(), steps);
+    delete root;
+}
+
+TEST(WalkNode, RotateLeftRightRand2D) {
+    int num_sites = 100;
+    auto steps = random_walk<2>(num_sites);
+
+    auto root1 = walk_node<2>::balanced_rep(steps);
+    auto root2 = walk_node<2>::balanced_rep(steps);
+    EXPECT_EQ(*root1->rotate_left()->rotate_right(), *root2);
+    delete root1;
+    delete root2;
+}
+
+TEST(WalkNode, RotateRightLeftRand2D) {
+    int num_sites = 100;
+    auto steps = random_walk<2>(num_sites);
+
+    auto root1 = walk_node<2>::balanced_rep(steps);
+    auto root2 = walk_node<2>::balanced_rep(steps);
+    EXPECT_EQ(*root1->rotate_right()->rotate_left(), *root2);
+    delete root1;
+    delete root2;
 }


### PR DESCRIPTION
In #31 the mistaken claim was made that the bounding box for a given span of points does not need to be adjusted when constructing the balanced tree representation of a sequence of steps. This is slightly mistaken: although the box constructor ensures that its result is properly anchored, it does not correctly account for the global symmetry propagated in #31. This PR corrects this error and adds a number of tests for the balanced representation, as well as for rotations of walk trees.