### PR TITLE
Refactor and tidy up operators

### DIFF
--- a/src/include/lattice.h
+++ b/src/include/lattice.h
@@ -112,7 +112,7 @@ template <int Dim> struct box : boost::additive<box<Dim>, point<Dim>> {
    * The union here is not to be understood as the set-theoretic union, but rather as the minimal
    * bounding box containing both input boxes.
    */
-  box operator+(const box &b) const;
+  box operator|(const box &b) const;
 
   /**
    * @brief Returns the intersection of two boxes.
@@ -120,7 +120,7 @@ template <int Dim> struct box : boost::additive<box<Dim>, point<Dim>> {
    * The intersection is the set-theoretic intersection or, equivalently, the maximal box contained
    * in both input boxes.
    */
-  box operator*(const box &b) const;
+  box operator&(const box &b) const;
 
   /** @brief Returns the string of the form "{intervals_[0]} x ... x {intervals[Dim - 1]}". */
   std::string to_string() const;

--- a/src/include/lattice.h
+++ b/src/include/lattice.h
@@ -77,7 +77,7 @@ private:
 template <typename S, typename T, T Dim> point(std::array<S, Dim>) -> point<Dim>;
 
 /** @brief Represents a Dim-dimensional box. */
-template <int Dim> struct box : boost::addable<box<Dim>, point<Dim>> {
+template <int Dim> struct box : boost::additive<box<Dim>, point<Dim>> {
   std::array<interval, Dim> intervals_;
 
   box() = delete;
@@ -103,6 +103,8 @@ template <int Dim> struct box : boost::addable<box<Dim>, point<Dim>> {
 
   /** @brief Action of a point (understood as a vector) on a box */
   box<Dim> &operator+=(const point<Dim> &b);
+
+  box<Dim> &operator-=(const point<Dim> &b);
 
   /**
    * @brief Returns the "union" of two boxes.

--- a/src/include/lattice.h
+++ b/src/include/lattice.h
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include <boost/operators.hpp>
+
 namespace pivot {
 
 template <int Dim> struct box;
@@ -34,7 +36,7 @@ struct interval {
 /**
  * @brief Represents a Dim-dimensional point.
  */
-template <int Dim> class point {
+template <int Dim> class point : boost::multipliable<point<Dim>, int> {
 
 public:
   point() = default;
@@ -57,14 +59,11 @@ public:
   /** @brief Vector addition of points */
   point operator+(const point &p) const;
 
-  /** @brief Action of a point (understood as a vector) on a box */
-  box<Dim> operator+(const box<Dim> &b) const;
-
   /** @brief Vector subtraction of points */
   point operator-(const point &p) const;
 
   /** @brief Scalar multiplication of a point */
-  template <int D> friend point<D> operator*(int k, const point<D> &p);
+  point &operator*=(int k);
 
   int norm() const;
 
@@ -78,7 +77,7 @@ private:
 template <typename S, typename T, T Dim> point(std::array<S, Dim>) -> point<Dim>;
 
 /** @brief Represents a Dim-dimensional box. */
-template <int Dim> struct box {
+template <int Dim> struct box : boost::addable<box<Dim>, point<Dim>> {
   std::array<interval, Dim> intervals_;
 
   box() = delete;
@@ -101,6 +100,9 @@ template <int Dim> struct box {
   interval operator[](int i) const;
 
   bool empty() const;
+
+  /** @brief Action of a point (understood as a vector) on a box */
+  box<Dim> &operator+=(const point<Dim> &b);
 
   /**
    * @brief Returns the "union" of two boxes.

--- a/src/utils/lattice.cpp
+++ b/src/utils/lattice.cpp
@@ -148,7 +148,7 @@ template <int Dim> bool box<Dim>::empty() const {
   return std::any_of(intervals_.begin(), intervals_.end(), [](const interval &i) { return i.empty(); });
 }
 
-template <int Dim> box<Dim> box<Dim>::operator+(const box<Dim> &b) const {
+template <int Dim> box<Dim> box<Dim>::operator|(const box<Dim> &b) const {
   std::array<interval, Dim> intervals;
   for (int i = 0; i < Dim; ++i) {
     intervals[i] = interval(std::min(intervals_[i].left_, b.intervals_[i].left_),
@@ -157,7 +157,7 @@ template <int Dim> box<Dim> box<Dim>::operator+(const box<Dim> &b) const {
   return box(intervals);
 }
 
-template <int Dim> box<Dim> box<Dim>::operator*(const box<Dim> &b) const {
+template <int Dim> box<Dim> box<Dim>::operator&(const box<Dim> &b) const {
   std::array<interval, Dim> intervals;
   for (int i = 0; i < Dim; ++i) {
     intervals[i] = interval(std::max(intervals_[i].left_, b.intervals_[i].left_),

--- a/src/utils/lattice.cpp
+++ b/src/utils/lattice.cpp
@@ -34,12 +34,12 @@ template <int Dim> point<Dim> point<Dim>::operator+(const point<Dim> &p) const {
   return point(sum);
 }
 
-template <int Dim> box<Dim> point<Dim>::operator+(const box<Dim> &b) const {
-  std::array<interval, Dim> intervals;
+template <int Dim> box<Dim> &box<Dim>::operator+=(const point<Dim> &p) {
   for (int i = 0; i < Dim; ++i) {
-    intervals[i] = interval(coords_[i] + b.intervals_[i].left_, coords_[i] + b.intervals_[i].right_);
+    intervals_[i].left_ += p[i];
+    intervals_[i].right_ += p[i];
   }
-  return box<Dim>(intervals);
+  return *this;
 }
 
 template <int Dim> point<Dim> point<Dim>::operator-(const point &p) const {
@@ -50,12 +50,11 @@ template <int Dim> point<Dim> point<Dim>::operator-(const point &p) const {
   return point(diff);
 }
 
-template <int Dim> point<Dim> operator*(int k, const point<Dim> &p) {
-  std::array<int, Dim> coords;
+template <int Dim> point<Dim> &point<Dim>::operator*=(int k) {
   for (int i = 0; i < Dim; ++i) {
-    coords[i] = k * p.coords_[i];
+    coords_[i] *= k;
   }
-  return point(coords);
+  return *this;
 }
 
 template <int Dim> int point<Dim>::norm() const {
@@ -296,7 +295,6 @@ template <int Dim> void to_csv(const std::string &path, const std::vector<point<
 #define POINT_INST(z, n, data) template class point<n>;
 #define BOX_INST(z, n, data) template struct box<n>;
 #define TRANSFORM_INST(z, n, data) template class transform<n>;
-#define POINT_SCALAR_MULT_INST(z, n, data) template point<n> operator*(int k, const point<n> &p);
 #define POINT_HASH_CALL_INST(z, n, data) template std::size_t point_hash::operator()<n>(const point<n> &p) const;
 #define TO_CSV_INST(z, n, data) template void to_csv<n>(const std::string &path, const std::vector<point<n>> &points);
 
@@ -304,7 +302,6 @@ template <int Dim> void to_csv(const std::string &path, const std::vector<point<
 BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, POINT_INST, ~)
 BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, BOX_INST, ~)
 BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, TRANSFORM_INST, ~)
-BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, POINT_SCALAR_MULT_INST, ~)
 BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, POINT_HASH_CALL_INST, ~)
 BOOST_PP_REPEAT_FROM_TO(1, DIMS_UB, TO_CSV_INST, ~)
 

--- a/src/utils/lattice.cpp
+++ b/src/utils/lattice.cpp
@@ -42,6 +42,14 @@ template <int Dim> box<Dim> &box<Dim>::operator+=(const point<Dim> &p) {
   return *this;
 }
 
+template <int Dim> box<Dim> &box<Dim>::operator-=(const point<Dim> &b) {
+  for (int i = 0; i < Dim; ++i) {
+    intervals_[i].left_ -= b[i];
+    intervals_[i].right_ -= b[i];
+  }
+  return *this;
+}
+
 template <int Dim> point<Dim> point<Dim>::operator-(const point &p) const {
   std::array<int, Dim> diff;
   for (int i = 0; i < Dim; ++i) {

--- a/src/walks/walk_node.cpp
+++ b/src/walks/walk_node.cpp
@@ -263,7 +263,7 @@ bool intersect(const walk_node<Dim> *l_walk, const walk_node<Dim> *r_walk, const
                const point<Dim> &r_anchor, const transform<Dim> &l_symm, const transform<Dim> &r_symm) {
   auto l_box = l_anchor + l_symm * l_walk->bbox_;
   auto r_box = r_anchor + r_symm * r_walk->bbox_;
-  if ((l_box * r_box).empty()) {
+  if ((l_box & r_box).empty()) {
     return false;
   }
 
@@ -285,7 +285,7 @@ bool intersect(const walk_node<Dim> *l_walk, const walk_node<Dim> *r_walk, const
 template <int Dim> void walk_node<Dim>::merge() {
   num_sites_ = left_->num_sites_ + right_->num_sites_;
 
-  bbox_ = left_->bbox_ + (left_->end_ + symm_ * right_->bbox_);
+  bbox_ = left_->bbox_ | (left_->end_ + symm_ * right_->bbox_);
   end_ = left_->end_ + symm_ * right_->end_;
 }
 

--- a/src/walks/walk_node.cpp
+++ b/src/walks/walk_node.cpp
@@ -57,7 +57,7 @@ walk_node<Dim> *walk_node<Dim>::balanced_rep(std::span<const point<Dim>> steps, 
   auto glob_inv = glob_symm.inverse();
   auto rel_symm = glob_inv * abs_symm;
   auto rel_end = glob_inv * (steps.back() - steps.front()) + pivot::point<Dim>::unit(0);
-  auto rel_box = point<Dim>::unit(0) + glob_inv * (point<Dim>() - point<Dim>::unit(0) + box(steps));
+  auto rel_box = point<Dim>::unit(0) + glob_inv * (box(steps) - point<Dim>::unit(0));
   walk_node *root = new walk_node(start + n - 1, num_sites, rel_symm, rel_box, rel_end);
 
   if (n >= 1) {

--- a/tests/lattice_test.cpp
+++ b/tests/lattice_test.cpp
@@ -75,17 +75,17 @@ TEST(BoxTest, FromSpan2D) {
 TEST(BoxTest, Union1D) {
     box<1> b1({interval{-1, 1}});
     box<1> b2({interval{0, 2}});
-    auto b3 = b1 + b2;
+    auto b3 = b1 | b2;
     EXPECT_EQ(b3.intervals_[0].left_, -1);
     EXPECT_EQ(b3.intervals_[0].right_, 2);
 
     box<1> b4({interval{2, 3}});
-    auto b5 = b1 + b4;
+    auto b5 = b1 | b4;
     EXPECT_EQ(b5.intervals_[0].left_, -1);
     EXPECT_EQ(b5.intervals_[0].right_, 3);
 
     box<1> b6({interval{0, 1}});
-    auto b7 = b1 + b6;
+    auto b7 = b1 | b6;
     EXPECT_EQ(b7.intervals_[0].left_, -1);
     EXPECT_EQ(b7.intervals_[0].right_, 1);
 }
@@ -93,14 +93,14 @@ TEST(BoxTest, Union1D) {
 TEST(BoxTest, Union2D) {
     box<2> b1({interval{-1, 1}, interval{0, 1}});
     box<2> b2({interval{0, 2}, interval{0, 2}});
-    auto b3 = b1 + b2;
+    auto b3 = b1 | b2;
     EXPECT_EQ(b3.intervals_[0].left_, -1);
     EXPECT_EQ(b3.intervals_[0].right_, 2);
     EXPECT_EQ(b3.intervals_[1].left_, 0);
     EXPECT_EQ(b3.intervals_[1].right_, 2);
 
     box<2> b4({interval{2, 3}, interval{1, 2}});
-    auto b5 = b1 + b4;
+    auto b5 = b1 | b4;
     EXPECT_EQ(b5.intervals_[0].left_, -1);
     EXPECT_EQ(b5.intervals_[0].right_, 3);
     EXPECT_EQ(b5.intervals_[1].left_, 0);
@@ -110,16 +110,16 @@ TEST(BoxTest, Union2D) {
 TEST(BoxTest, Intersection1D) {
     box<1> b1({interval{-1, 1}});
     box<1> b2({interval{0, 2}});
-    auto b3 = b1 * b2;
+    auto b3 = b1 & b2;
     EXPECT_EQ(b3.intervals_[0].left_, 0);
     EXPECT_EQ(b3.intervals_[0].right_, 1);
 
     box<1> b4({interval{2, 3}});
-    auto b5 = b1 * b4;
+    auto b5 = b1 & b4;
     EXPECT_TRUE(b5.empty());
 
     box<1> b6({interval{1, 2}});
-    auto b7 = b1 * b6;
+    auto b7 = b1 & b6;
     EXPECT_EQ(b7.intervals_[0].left_, 1);
     EXPECT_EQ(b7.intervals_[0].right_, 1);
 }
@@ -127,14 +127,14 @@ TEST(BoxTest, Intersection1D) {
 TEST(BoxTest, Intersection2D) {
     box<2> b1({interval{-1, 1}, interval{0, 1}});
     box<2> b2({interval{0, 2}, interval{0, 2}});
-    auto b3 = b1 * b2;
+    auto b3 = b1 & b2;
     EXPECT_EQ(b3.intervals_[0].left_, 0);
     EXPECT_EQ(b3.intervals_[0].right_, 1);
     EXPECT_EQ(b3.intervals_[1].left_, 0);
     EXPECT_EQ(b3.intervals_[1].right_, 1);
 
     box<2> b4({interval{2, 3}, interval{1, 2}});
-    auto b5 = b1 * b4;
+    auto b5 = b1 & b4;
     EXPECT_TRUE(b5.empty());
 }
 


### PR DESCRIPTION
Use boost to reduce operator boilerplate and use bitwise (& and |) operators for box union and intersection.