### PR TITLE
Add method to find node by id in constant time

### DIFF
--- a/src/include/walk_node.h
+++ b/src/include/walk_node.h
@@ -16,14 +16,15 @@ template <int Dim> class walk_tree;
 template <int Dim> class walk_node {
 
 public:
-  static walk_node *pivot_rep(const std::vector<point<Dim>> &steps);
+  static walk_node *pivot_rep(const std::vector<point<Dim>> &steps, walk_node *buf = nullptr);
 
   /** @brief Create a balanced tree representation of a walk given by a sequence of points.
    *
    * @param steps The steps of the walk.
+   * @param buf An optional buffer to use for the tree nodes.
    * @return The root of the walk tree.
    */
-  static walk_node *balanced_rep(const std::vector<point<Dim>> &steps);
+  static walk_node *balanced_rep(const std::vector<point<Dim>> &steps, walk_node *buf = nullptr);
 
   walk_node(const walk_node &w) = delete;
   walk_node(walk_node &&w) = delete;
@@ -73,7 +74,8 @@ private:
 
   walk_node(int id, int num_sites, const transform<Dim> &symm, const box<Dim> &bbox, const point<Dim> &end);
 
-  static walk_node *balanced_rep(std::span<const point<Dim>> steps, int start, const transform<Dim> &glob_symm);
+  static walk_node *balanced_rep(std::span<const point<Dim>> steps, int start, const transform<Dim> &glob_symm,
+                                 walk_node *buf);
 
   void set_left(walk_node *left) {
     left_ = left;

--- a/src/include/walk_node.h
+++ b/src/include/walk_node.h
@@ -32,6 +32,8 @@ public:
 
   ~walk_node();
 
+  int id() const { return id_; }
+
   const box<Dim> &bbox() const { return bbox_; }
 
   const point<Dim> &endpoint() const { return end_; }

--- a/src/include/walk_tree.h
+++ b/src/include/walk_tree.h
@@ -30,6 +30,16 @@ public:
 
   bool is_leaf() const;
 
+  /**
+   * @brief Find a node by its id
+   * @param n node id
+   * @note Runs in constant time.
+   * @warning This function can only be used on trees initialized with balanced=true. Moreover,
+   * it cannot be used on trees currently being transformed (e.g. via rotation).
+   * @return reference to the node
+   */
+  walk_node<Dim> &find_node(int n);
+
   bool try_pivot(int n, const transform<Dim> &r);
 
   bool rand_pivot() override;

--- a/src/include/walk_tree.h
+++ b/src/include/walk_tree.h
@@ -24,6 +24,8 @@ public:
 
   ~walk_tree();
 
+  walk_node<Dim> *root() const;
+
   point<Dim> endpoint() const override;
 
   bool is_leaf() const;
@@ -42,6 +44,7 @@ private:
   std::unique_ptr<walk_node<Dim>> root_;
   std::mt19937 rng_;
   std::uniform_int_distribution<int> dist_;
+  walk_node<Dim> *buf_;
 
   walk_tree(walk_node<Dim> *root);
 };

--- a/src/walks/walk_node.cpp
+++ b/src/walks/walk_node.cpp
@@ -12,31 +12,37 @@ walk_node<Dim>::walk_node(int id, int num_sites, const transform<Dim> &symm, con
                           const point<Dim> &end)
     : id_(id), num_sites_(num_sites), symm_(symm), bbox_(bbox), end_(end) {}
 
-template <int Dim> walk_node<Dim> *walk_node<Dim>::pivot_rep(const std::vector<point<Dim>> &steps) {
+template <int Dim> walk_node<Dim> *walk_node<Dim>::pivot_rep(const std::vector<point<Dim>> &steps, walk_node *buf) {
   int num_sites = steps.size();
   if (num_sites < 2) {
     throw std::invalid_argument("num_sites must be at least 2");
   }
   walk_node<Dim> *root =
-      new walk_node(1, num_sites, transform(steps[0], steps[1]), box<Dim>(steps), steps[num_sites - 1]);
+      buf ? new (buf) walk_node(1, num_sites, transform(steps[0], steps[1]), box<Dim>(steps), steps[num_sites - 1])
+          : new walk_node(1, num_sites, transform(steps[0], steps[1]), box<Dim>(steps), steps[num_sites - 1]);
   auto node = root;
   for (int i = 0; i < num_sites - 2; ++i) {
-    node->right_ = new walk_node(i + 2, num_sites - i - 1, transform(steps[i + 1], steps[i + 2]),
-                                 box(std::span<const point<Dim>>(steps).subspan(i + 1)),
-                                 steps[num_sites - 1]); // TODO: double-check this
+    auto id = i + 2;
+    node->right_ = buf ? new (buf + id - 1)
+                             walk_node(id, num_sites - i - 1, transform(steps[i + 1], steps[i + 2]),
+                                       box(std::span<const point<Dim>>(steps).subspan(i + 1)), steps[num_sites - 1])
+                       : new walk_node(i + 2, num_sites - i - 1, transform(steps[i + 1], steps[i + 2]),
+                                       box(std::span<const point<Dim>>(steps).subspan(i + 1)),
+                                       steps[num_sites - 1]); // TODO: double-check this
     node->right_->parent_ = node;
     node = node->right_;
   }
   return root;
 }
 
-template <int Dim> walk_node<Dim> *walk_node<Dim>::balanced_rep(const std::vector<point<Dim>> &steps) {
-  return balanced_rep(steps, 1, transform<Dim>());
+template <int Dim>
+walk_node<Dim> *walk_node<Dim>::balanced_rep(const std::vector<point<Dim>> &steps, walk_node<Dim> *buf) {
+  return balanced_rep(steps, 1, transform<Dim>(), buf);
 }
 
 template <int Dim>
 walk_node<Dim> *walk_node<Dim>::balanced_rep(std::span<const point<Dim>> steps, int start,
-                                             const transform<Dim> &glob_symm) {
+                                             const transform<Dim> &glob_symm, walk_node<Dim> *buf) {
   int num_sites = steps.size();
   if (num_sites < 1) {
     throw std::invalid_argument("num_sites must be at least 1");
@@ -48,24 +54,23 @@ walk_node<Dim> *walk_node<Dim>::balanced_rep(std::span<const point<Dim>> steps, 
   /* The steps span gives an "absolute" view of the walk, but a "relative" view is required, since each sub-tree,
   including the current one, must itself be a walk anchored at the first coordinate vector. The "global symmetry"
   glob_symm represents the transformation "accumulated" since the root of the tree under construction. Its effect
-  must be reversed in order to obtain the relative properties of the current node.
-
-  We don't need to transform the box since box(span<point>) constructor already anchors its result correctly.
-  TODO: ideally we should have similar methods for constructing transforms and endpoint */
+  must be reversed in order to obtain the relative properties of the current node. */
   int n = std::floor((1 + num_sites) / 2.0);
   auto abs_symm = transform(steps[n - 1], steps[n]);
   auto glob_inv = glob_symm.inverse();
   auto rel_symm = glob_inv * abs_symm;
   auto rel_end = glob_inv * (steps.back() - steps.front()) + pivot::point<Dim>::unit(0);
   auto rel_box = point<Dim>::unit(0) + glob_inv * (box(steps) - point<Dim>::unit(0));
-  walk_node *root = new walk_node(start + n - 1, num_sites, rel_symm, rel_box, rel_end);
+  int id = start + n - 1;
+  walk_node *root = buf ? new (buf + id - 1) walk_node(id, num_sites, rel_symm, rel_box, rel_end)
+                        : new walk_node(id, num_sites, rel_symm, rel_box, rel_end);
 
   if (n >= 1) {
-    root->left_ = balanced_rep(steps.subspan(0, n), start, glob_symm);
+    root->left_ = balanced_rep(steps.subspan(0, n), start, glob_symm, buf);
     root->left_->parent_ = root;
   }
   if (num_sites - n >= 1) {
-    root->right_ = balanced_rep(steps.subspan(n), start + n, rel_symm * glob_symm);
+    root->right_ = balanced_rep(steps.subspan(n), start + n, rel_symm * glob_symm, buf);
     root->right_->parent_ = root;
   }
   return root;
@@ -85,14 +90,7 @@ template <int Dim> walk_node<Dim> &walk_node<Dim>::leaf() {
   return leaf;
 }
 
-template <int Dim> walk_node<Dim>::~walk_node() {
-  if (left_ != nullptr && left_ != &leaf()) {
-    delete left_;
-  }
-  if (right_ != nullptr && right_ != &leaf()) {
-    delete right_;
-  }
-}
+template <int Dim> walk_node<Dim>::~walk_node() = default;
 
 template <int Dim> bool walk_node<Dim>::operator==(const walk_node &other) const {
   if (is_leaf() && other.is_leaf()) {

--- a/src/walks/walk_tree.cpp
+++ b/src/walks/walk_tree.cpp
@@ -66,6 +66,15 @@ template <int Dim> bool walk_tree<Dim>::is_leaf() const { return root_->is_leaf(
 
 template <int Dim> std::vector<point<Dim>> walk_tree<Dim>::steps() const { return root_->steps(); }
 
+template <int Dim> walk_node<Dim> &walk_tree<Dim>::find_node(int n) {
+  if (!buf_) {
+    throw std::runtime_error("find_node can only be used on trees initialized with balanced=true");
+  }
+  walk_node<Dim> &result = buf_[n - 1];
+  assert(result.id_ == n);
+  return result;
+}
+
 template <int Dim> bool walk_tree<Dim>::try_pivot(int n, const transform<Dim> &r) {
   root_->shuffle_up(n);
   root_->symm_ = root_->symm_ * r; // modify in-place

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -4,6 +4,7 @@
 
 #include "loop.h"
 #include "walk.h"
+#include "walk_node.h"
 #include "walk_tree.h"
 
 using namespace pivot;
@@ -50,6 +51,17 @@ TEST(WalkTreeTest, SelfAvoiding) {
       }
       EXPECT_TRUE(w.self_avoiding());
     }
+  }
+}
+
+TEST(WalkTreeTest, FindNode) {
+  auto w = walk_tree<2>(100);
+  for (int i = 1; i <= 100; ++i) {
+    w.rand_pivot();
+  }
+  for (int i = 1; i < 100; ++i) {
+    auto &node = w.find_node(i);
+    ASSERT_EQ(node.id(), i);
   }
 }
 

--- a/tests/walk_node_test.cpp
+++ b/tests/walk_node_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "walk_node.h"
+#include "walk_tree.h"
 
 #include "test_utils.h"
 
@@ -10,7 +11,8 @@ using namespace pivot;
 
 TEST(WalkNode, Balanced1) {
     auto steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({2, 1}), pivot::point<2>({3, 1})};
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
 
     auto symm = root->symm();
     auto end = root->endpoint();
@@ -42,15 +44,14 @@ TEST(WalkNode, Balanced1) {
     EXPECT_TRUE(left->right()->is_leaf());
     EXPECT_TRUE(right->left()->is_leaf());
     EXPECT_TRUE(right->right()->is_leaf());
-
-    delete root;
 }
 
 TEST(WalkNode, Balanced2) {
     // steps and tree from Clisby (2010), Figs. 1, 23
     auto steps = {pivot::point<2>({1, 0}), pivot::point<2>({1, 1}), pivot::point<2>({2, 1}), pivot::point<2>({3, 1}),
                   pivot::point<2>({3, 0})};
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
 
     auto symm = root->symm();
     auto end = root->endpoint();
@@ -92,12 +93,12 @@ TEST(WalkNode, Balanced2) {
     EXPECT_TRUE(left->left()->left()->is_leaf());
     EXPECT_TRUE(left->left()->right()->is_leaf());
 
-    delete root;
 }
 
 TEST(WalkNode, Balanced3) {
     std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({2, 1}), pivot::point<2>({2, 2})};
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
 
     auto symm = root->symm();
     auto end = root->endpoint();
@@ -130,7 +131,6 @@ TEST(WalkNode, Balanced3) {
     EXPECT_TRUE(right->left()->is_leaf());
     EXPECT_TRUE(right->right()->is_leaf());
 
-    delete root;
 }
 
 TEST(RandomWalk, IsNearestNeighbor) {
@@ -143,15 +143,16 @@ TEST(RandomWalk, IsNearestNeighbor) {
 
 TEST(WalkNode, BalancedSteps) {
     auto steps = random_walk<2>(100);
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
     auto result = root->steps();
     EXPECT_EQ(steps, result);
-    delete root;
 }
 
 TEST(WalkNode, RotateRight2D1) {
     std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({2, 0}), pivot::point<2>({3, 0})};
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
 
     root->rotate_right();
     auto symm = root->symm();
@@ -176,12 +177,12 @@ TEST(WalkNode, RotateRight2D1) {
     EXPECT_TRUE(right->left()->is_leaf());
     EXPECT_TRUE(right->right()->is_leaf());
 
-    delete root;
 }
 
 TEST(WalkNode, RotateRight2D2) {
     std::vector steps = {pivot::point<2>({1, 0}), pivot::point<2>({1, 1}), pivot::point<2>({1, 2})};
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
 
     root->rotate_right();
     auto symm = root->symm();
@@ -206,47 +207,46 @@ TEST(WalkNode, RotateRight2D2) {
     EXPECT_TRUE(right->left()->is_leaf());
     EXPECT_TRUE(right->right()->is_leaf());
 
-    delete root;
 }
 
 TEST(WalkNode, RotateRightStepsRand2D) {
     int num_sites = 100;
     auto steps = random_walk<2>(num_sites);
 
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
     ASSERT_EQ(root->steps(), steps);
     EXPECT_EQ(root->rotate_right()->steps(), steps);
-    delete root;
 }
 
 TEST(WalkNode, RotateLeftStepsRand2D) {
     int num_sites = 100;
     auto steps = random_walk<2>(num_sites);
 
-    auto root = walk_node<2>::balanced_rep(steps);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
     ASSERT_EQ(root->steps(), steps);
     EXPECT_EQ(root->rotate_left()->steps(), steps);
-    delete root;
 }
 
 TEST(WalkNode, RotateLeftRightRand2D) {
     int num_sites = 100;
     auto steps = random_walk<2>(num_sites);
 
-    auto root1 = walk_node<2>::balanced_rep(steps);
-    auto root2 = walk_node<2>::balanced_rep(steps);
+    auto tree1 = walk_tree<2>(steps);
+    auto root1 = tree1.root();
+    auto tree2 = walk_tree<2>(steps);
+    auto root2 = tree2.root();
     EXPECT_EQ(*root1->rotate_left()->rotate_right(), *root2);
-    delete root1;
-    delete root2;
 }
 
 TEST(WalkNode, RotateRightLeftRand2D) {
     int num_sites = 100;
     auto steps = random_walk<2>(num_sites);
 
-    auto root1 = walk_node<2>::balanced_rep(steps);
-    auto root2 = walk_node<2>::balanced_rep(steps);
+    auto tree1 = walk_tree<2>(steps);
+    auto root1 = tree1.root();
+    auto tree2 = walk_tree<2>(steps);
+    auto root2 = tree2.root();
     EXPECT_EQ(*root1->rotate_right()->rotate_left(), *root2);
-    delete root1;
-    delete root2;
 }

--- a/tests/walk_tree_test.cpp
+++ b/tests/walk_tree_test.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include "walk_node.h"
 #include "walk_tree.h"
 
 using namespace pivot;
@@ -14,6 +15,10 @@ TEST(WalkTreeInit, Line) {
     }
     EXPECT_FALSE(w.is_leaf());
     EXPECT_EQ(w.endpoint(), pivot::point<2>({5, 0}));
+    for (int i = 1; i <= 4; i++) {
+        auto &node = w.find_node(i);
+        EXPECT_EQ(node.id(), i);
+    }
 }
 
 TEST(WalkTreePivot, PivotLine) {


### PR DESCRIPTION
Used in Clisby's shuffle_intersect method required by his "fast" pivot method.

Works by allocating nodes into predictable regions of a given buffer. Only works when the tree is balanced.
This approach avoids adding additional data members to walk_tree data structure and has the added potential bonus of localizing the tree in memory.