### PR TITLE
Fix action of transform on point

### DIFF
--- a/src/include/lattice.h
+++ b/src/include/lattice.h
@@ -153,7 +153,8 @@ struct point_hash {
  * @details Such a transformation can be represented by the matrix product S P of a
  * permutation matrix P and a diagonal matrix S with diagonal entries equal to plus or
  * minus one. We denote the action of the permutation on an integer by P(i) and the diagonal
- * entries of S by S(i).
+ * entries of S by S(i). Note that P e(i) = e(P(i)) and S e(i) = S(i) e(i), where e(i)
+ * is the i-th standard unit vector.
  */
 template <int Dim> class transform {
 
@@ -193,7 +194,15 @@ public:
 
   bool operator==(const transform &t) const;
 
-  /** @brief Transforms a point. */
+  /**
+   * @brief Action of a transform on a point.
+   *
+   * @details Given matrix representations (see @ref transform_details) S P of *this and a point p,
+   *
+   * \f[ S P p = S P \sum_j p[j] e(j) = \sum_j S(P(j)) p[j] e(P(j)) \f]
+   *
+   * which means the P(i)-th component of the result is S(P(i)) p[i].
+   */
   point<Dim> operator*(const point<Dim> &p) const;
 
   /**

--- a/src/utils/lattice/transform.hpp
+++ b/src/utils/lattice/transform.hpp
@@ -52,7 +52,7 @@ template <int Dim> bool transform<Dim>::operator==(const transform &t) const {
 template <int Dim> point<Dim> transform<Dim>::operator*(const point<Dim> &p) const {
   std::array<int, Dim> coords;
   for (int i = 0; i < Dim; ++i) {
-    coords[i] = signs_[i] * p[perm_[i]];
+    coords[perm_[i]] = signs_[perm_[i]] * p[i];
   }
   return point<Dim>(coords);
 }

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -21,6 +21,18 @@ TEST(WalkTest, SelfAvoiding) {
   }
 }
 
+TEST(WalkTest, SelfAvoiding3D) {
+  for (int num_steps = 2; num_steps < 10; ++num_steps) {
+    walk<3> w(100);
+    for (int i = 0; i < 10; ++i) {
+      for (int j = 0; j < 100; j++) {
+        w.rand_pivot();
+      }
+      EXPECT_TRUE(w.self_avoiding());
+    }
+  }
+}
+
 TEST(WalkTest, Seed) {
   std::random_device rd;
   auto seed = rd();

--- a/tests/lattice_test.cpp
+++ b/tests/lattice_test.cpp
@@ -192,6 +192,21 @@ TEST(TransformTest, Box2D) {
     EXPECT_EQ(t2 * b, box<2>({interval{-5, -1}, interval{2, 4}}));
 }
 
+TEST(TransformTest, Box3D) {
+    box<3> b({interval{1, 5}, interval{2, 4}, interval{3, 6}});
+
+    point<3> p1({0, 0, 0});
+    point<3> p2({0, 1, 0});
+    transform<3> t1(p1, p2);
+    EXPECT_EQ(t1 * b, box<3>({interval{-4, -2}, interval{1, 5}, interval{3, 6}}));
+
+    transform<3> t2({0, 1, 2}, {-1, 1, 1});
+    EXPECT_EQ(t2 * b, box<3>({interval{-5, -1}, interval{2, 4}, interval{3, 6}}));
+
+    transform<3> t3({2, 0, 1}, {1, 1, 1});
+    EXPECT_EQ(t3 * b, box<3>({interval{2, 4}, interval{3, 6}, interval{1, 5}}));
+}
+
 TEST(TransformTest, Inverse2D) {
     transform<2> id({0, 1}, {1, 1});
     auto o = point<2>({0, 0});

--- a/tests/lattice_test.cpp
+++ b/tests/lattice_test.cpp
@@ -172,11 +172,19 @@ TEST(TransformTest, Pivot3D) {
     EXPECT_EQ(p1 + t2 * e0, p3);
 }
 
-TEST(TransformTest, Compose) {
+TEST(TransformTest, Compose2D) {
     auto t1 = transform<2>::rand();
     auto t2 = transform<2>::rand();
     auto t3 = t1 * t2;
     auto p = point<2>({1, 2});
+    EXPECT_EQ(t3 * p, t1 * (t2 * p)) << "t1: " << t1.to_string() << ", t2: " << t2.to_string();
+}
+
+TEST(TransformTest, Compose3D) {
+    auto t1 = transform<3>::rand();
+    auto t2 = transform<3>::rand();
+    auto t3 = t1 * t2;
+    auto p = point<3>({1, 2, 3});
     EXPECT_EQ(t3 * p, t1 * (t2 * p)) << "t1: " << t1.to_string() << ", t2: " << t2.to_string();
 }
 

--- a/tests/lattice_test.cpp
+++ b/tests/lattice_test.cpp
@@ -214,3 +214,22 @@ TEST(TransformTest, Inverse2D) {
     EXPECT_EQ(ttinv, id);
     EXPECT_EQ(tinvt, id);
 }
+
+TEST(TransformTest, Inverse3D) {
+    transform<3> id({0, 1, 2}, {1, 1, 1});
+    auto e1 = point<3>({1, 0, 0});
+    auto e2 = point<3>({0, 1, 0});
+    auto e3 = point<3>({0, 0, 1});
+    ASSERT_EQ(e1, id * e1);
+    ASSERT_EQ(e2, id * e2);
+    ASSERT_EQ(e3, id * e3);
+
+    transform<3> t({2, 0, 1}, {-1, 1, -1});
+    transform<3> t_inv = t.inverse();
+    auto f1 = t * e1;
+    auto f2 = t * e2;
+    auto f3 = t * e3;
+    EXPECT_EQ(e1, t_inv * f1);
+    EXPECT_EQ(e2, t_inv * f2);
+    EXPECT_EQ(e3, t_inv * f3);
+}

--- a/tests/walk_node_test.cpp
+++ b/tests/walk_node_test.cpp
@@ -250,3 +250,11 @@ TEST(WalkNode, RotateRightLeftRand2D) {
     auto root2 = tree2.root();
     EXPECT_EQ(*root1->rotate_right()->rotate_left(), *root2);
 }
+
+TEST(WalkNode, Steps2D) {
+    auto steps = random_walk<2>(100);
+    auto tree = walk_tree<2>(steps);
+    auto root = tree.root();
+    auto result = root->steps();
+    EXPECT_EQ(steps, result);
+}


### PR DESCRIPTION
Transforms act by permuting coordinate axes, which means they act on the components of a point via the inverse permutation. This change fixes the failure to obey the self-avoidance constraint in dimensions greater than 2 (in dimension 2, every permutation is its own inverse).

This PR also adds more tests in dimension 3.