### PR TITLE
Implement Clisby's Shuffle_intersect and Attempt_pivot_fast

### DIFF
--- a/src/include/walk.h
+++ b/src/include/walk.h
@@ -32,7 +32,7 @@ public:
 
   std::pair<int, std::optional<std::vector<point<Dim>>>> try_rand_pivot() const;
 
-  bool rand_pivot() override;
+  bool rand_pivot(bool fast = false) override;
 
   bool rand_pivot(int num_workers);
 

--- a/src/include/walk_base.h
+++ b/src/include/walk_base.h
@@ -9,7 +9,7 @@ template <int Dim> class walk_base {
 public:
   virtual ~walk_base() = default;
 
-  virtual bool rand_pivot() = 0;
+  virtual bool rand_pivot(bool fast) = 0;
 
   virtual bool self_avoiding() const = 0;
 

--- a/src/include/walk_node.h
+++ b/src/include/walk_node.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+
 #include "defines.h"
 #include "graphviz.h"
 #include "lattice.h"
@@ -27,7 +29,8 @@ public:
    */
   static walk_node *balanced_rep(const std::vector<point<Dim>> &steps, walk_node *buf = nullptr);
 
-  walk_node(const walk_node &w) = delete;
+  walk_node(const walk_node &w) = default;
+
   walk_node(walk_node &&w) = delete;
   walk_node &operator=(const walk_node &w) = delete;
 
@@ -53,13 +56,16 @@ public:
 
   void todot(const std::string &path) const;
 
-  walk_node *rotate_left();
+  walk_node *rotate_left(bool set_parent = true);
 
-  walk_node *rotate_right();
+  walk_node *rotate_right(bool set_parent = true);
 
   walk_node *shuffle_up(int id);
 
   walk_node *shuffle_down();
+
+  bool shuffle_intersect(const transform<Dim> &t, std::optional<bool> was_left_child,
+                         std::optional<bool> is_left_child);
 
   bool intersect() const;
 

--- a/src/include/walk_tree.h
+++ b/src/include/walk_tree.h
@@ -44,7 +44,7 @@ public:
 
   bool try_pivot_fast(int n, const transform<Dim> &r);
 
-  bool rand_pivot() override;
+  bool rand_pivot(bool fast = true) override;
 
   std::vector<point<Dim>> steps() const;
 

--- a/src/include/walk_tree.h
+++ b/src/include/walk_tree.h
@@ -42,6 +42,8 @@ public:
 
   bool try_pivot(int n, const transform<Dim> &r);
 
+  bool try_pivot_fast(int n, const transform<Dim> &r);
+
   bool rand_pivot() override;
 
   std::vector<point<Dim>> steps() const;

--- a/src/loop.h
+++ b/src/loop.h
@@ -7,7 +7,7 @@
 #include "walk_tree.h"
 
 template <int Dim>
-int main_loop(int num_steps, int iters, bool naive, int seed, bool require_success, bool verify,
+int main_loop(int num_steps, int iters, bool naive, bool fast, int seed, bool require_success, bool verify,
               const std::string &in_path, const std::string &out_dir) {
   std::unique_ptr<pivot::walk_base<Dim>> w;
   if (!naive) {
@@ -43,7 +43,7 @@ int main_loop(int num_steps, int iters, bool naive, int seed, bool require_succe
       break;
     }
 
-    auto success = w->rand_pivot();
+    auto success = w->rand_pivot(fast);
     if (success) {
       endpoints.push_back(w->endpoint());
       ++num_success;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@
 
 #define CASE_MACRO(z, n, data)                                                                                         \
   case n:                                                                                                              \
-    return main_loop<n>(num_steps, iters, naive, seed, require_success, verify, in_path, out_dir);                     \
+    return main_loop<n>(num_steps, iters, naive, fast, seed, require_success, verify, in_path, out_dir);               \
     break;
 
 int main(int argc, char **argv) {
@@ -14,6 +14,7 @@ int main(int argc, char **argv) {
   int num_steps;
   int iters;
   bool naive{false};
+  std::optional<bool> fast_slow{std::nullopt};
   int num_workers{0};
   bool require_success{false};
   bool verify{false};
@@ -28,6 +29,7 @@ int main(int argc, char **argv) {
   app.add_option("-s,--steps", num_steps, "number of steps")->required();
   app.add_option("-i,--iters", iters, "number of iterations")->required();
   app.add_flag("--naive", naive, "use naive implementation (slower)");
+  app.add_flag("--fast,!--slow", fast_slow, "use fast implementation");
   app.add_option("-w,--workers", num_workers, "number of workers");
   app.add_flag("--success", require_success, "require success");
   app.add_flag("--verify", verify, "verify");
@@ -36,6 +38,12 @@ int main(int argc, char **argv) {
   app.add_option("--seed", seed, "seed")->default_val(std::random_device()());
 
   CLI11_PARSE(app, argc, argv);
+  bool fast;
+  if (fast_slow.has_value()) {
+    fast = fast_slow.value();
+  } else {
+    fast = !naive;
+  }
 
   switch (dim) {
     // cppcheck-suppress syntaxError

--- a/src/walks/walk.cpp
+++ b/src/walks/walk.cpp
@@ -38,7 +38,11 @@ template <int Dim> std::pair<int, std::optional<std::vector<point<Dim>>>> walk<D
   return {step, try_pivot(step, r)};
 }
 
-template <int Dim> bool walk<Dim>::rand_pivot() {
+template <int Dim> bool walk<Dim>::rand_pivot(bool fast) {
+  if (fast) { // TODO: implement Kennedy algorithm
+    throw std::invalid_argument("fast pivot not implemented for naive walk");
+  }
+
   auto [step, new_points] = try_rand_pivot();
   if (!new_points) {
     return false;

--- a/src/walks/walk_tree.cpp
+++ b/src/walks/walk_tree.cpp
@@ -89,6 +89,29 @@ template <int Dim> bool walk_tree<Dim>::try_pivot(int n, const transform<Dim> &r
   return success;
 }
 
+template <int Dim> bool walk_tree<Dim>::try_pivot_fast(int n, const transform<Dim> &t) {
+  walk_node<Dim> *w = &find_node(n); // TODO: a pointer seems to be needed, but why?
+
+  std::optional<bool> is_left_child;
+  if (w->parent_ == nullptr || w->parent_->left_ == nullptr) {
+    is_left_child = std::nullopt;
+  } else if (w->parent_->left_ == w) {
+    is_left_child = true;
+  } else {
+    is_left_child = false;
+  }
+
+  walk_node<Dim> w_copy(*w);
+  auto success = !w_copy.shuffle_intersect(t, std::nullopt, is_left_child);
+  if (success) {
+    root_->shuffle_up(n);
+    root_->symm_ = root_->symm_ * t;
+    root_->merge();
+    root_->shuffle_down();
+  }
+  return success;
+}
+
 template <int Dim> bool walk_tree<Dim>::rand_pivot() {
   auto site = dist_(rng_);
   auto r = transform<Dim>::rand(rng_);

--- a/src/walks/walk_tree.cpp
+++ b/src/walks/walk_tree.cpp
@@ -112,10 +112,10 @@ template <int Dim> bool walk_tree<Dim>::try_pivot_fast(int n, const transform<Di
   return success;
 }
 
-template <int Dim> bool walk_tree<Dim>::rand_pivot() {
+template <int Dim> bool walk_tree<Dim>::rand_pivot(bool fast) {
   auto site = dist_(rng_);
   auto r = transform<Dim>::rand(rng_);
-  return try_pivot(site, r);
+  return fast ? try_pivot_fast(site, r) : try_pivot(site, r);
 }
 
 template <int Dim> bool walk_tree<Dim>::self_avoiding() const {

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -55,11 +55,13 @@ TEST(WalkTest, Loop) {
 }
 
 TEST(WalkTreeTest, SelfAvoiding) {
+  std::mt19937 gen(std::random_device{}());
+  std::uniform_int_distribution<int> dist(0, 1);
   for (int num_steps = 2; num_steps < 10; ++num_steps) {
     auto w = walk_tree<2>(num_steps);
     for (int i = 0; i < 10; ++i) {
       for (int j = 0; j < 10; j++) {
-        w.rand_pivot();
+        w.rand_pivot(static_cast<bool>(dist(gen)));
       }
       EXPECT_TRUE(w.self_avoiding());
     }

--- a/tests/int_test.cpp
+++ b/tests/int_test.cpp
@@ -50,7 +50,7 @@ TEST(WalkTest, Seed) {
 }
 
 TEST(WalkTest, Loop) {
-  auto ret = main_loop<2>(100, 10, true, 42, false, false, "", "");
+  auto ret = main_loop<2>(100, 10, true, false, 42, false, false, "", "");
   ASSERT_EQ(ret, 0);
 }
 
@@ -113,6 +113,6 @@ TEST(WalkTreeTest, Seed) {
 }
 
 TEST(WalkTreeTest, Loop) {
-  auto ret = main_loop<2>(100, 10, false, 42, false, false, "", "");
+  auto ret = main_loop<2>(100, 10, false, true, 42, false, false, "", "");
   ASSERT_EQ(ret, 0);
 }

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-for FILE in $(find src -name *.cpp -o -name *.h -o -name *.hpp)
+for FILE in $(find src -name "*.cpp" -o -name "*.h" -o -name "*.hpp")
 do
     clang-format -i $FILE
 done

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -2,7 +2,7 @@
 
 set -e
 
-for FILE in $(find src -name *.cpp -o -name *.h)
+for FILE in $(find src -name "*.cpp" -o -name "*.h" -o -name "*.hpp")
 do
     clang-format -n --Werror $FILE
 done


### PR DESCRIPTION
This bottom-up variant of Clisby's Attempt_pivot checks for intersections in a copy of the saw-tree so that failed pivot attempts do not need to be reversed. The copy is constructed "upwards" (starting with the sub-tree whose root is the node corresponding to the current pivot site) by copying the parent of the current node at each recursion.

One detail Clisby's paper omits is how exactly a node should be copied. Copying entire sub-trees is expensive but it turns out simply copying the parent is insufficient. A detail left out of the paper is that one of the parent's children (depending on which "side" of the parent the current node is one) must also be copied and the parent must be linked to that node as well as to the current node. The reason for this is tree rotations (which are performed on the parent copy) involve modifications to a single child node. For similar reasons, a copy must be made prior to the first invocation of shuffle_intersect. In order to prevent inadvertent links between the copied and original trees, the tree rotation methods must also be modified.