### PR TITLE
clear simple TODOs

### DIFF
--- a/src/include/walk_node.h
+++ b/src/include/walk_node.h
@@ -136,11 +136,8 @@ public:
 
   /* OTHER FUNCTIONS */
 
-  // TODO: make private
   std::vector<point<Dim>> steps() const;
 
-  // TODO: make private
-  // TODO: add corresponding method to walk_tree
   void todot(const std::string &path) const;
 
 private:
@@ -159,17 +156,16 @@ private:
 
   walk_node(int id, int num_sites, const transform<Dim> &symm, const box<Dim> &bbox, const point<Dim> &end);
 
-  // TODO: don't set leaf parent
   void set_left(walk_node *left) {
     left_ = left;
-    if (left != nullptr) {
+    if (left != nullptr && !left->is_leaf()) {
       left->parent_ = this;
     }
   }
 
   void set_right(walk_node *right) {
     right_ = right;
-    if (right != nullptr) {
+    if (right != nullptr && !right->is_leaf()) {
       right->parent_ = this;
     }
   }

--- a/src/include/walk_tree.h
+++ b/src/include/walk_tree.h
@@ -145,6 +145,9 @@ public:
   /** @brief Export the walk to a CSV file. */
   void export_csv(const std::string &path) const override;
 
+  /** @brief Export tree to GraphViz format. */
+  void todot(const std::string &path) const;
+
 private:
   std::unique_ptr<walk_node<Dim>> root_;
   std::mt19937 rng_;

--- a/src/utils/lattice/box.hpp
+++ b/src/utils/lattice/box.hpp
@@ -8,8 +8,9 @@ interval::interval() : interval(0, 0) {}
 
 interval::interval(int left, int right) : left_(left), right_(right) {}
 
-// TODO: don't distinguish empty intervals
-bool interval::operator==(const interval &other) const { return left_ == other.left_ && right_ == other.right_; }
+bool interval::operator==(const interval &other) const {
+  return (left_ == other.left_ && right_ == other.right_) || (empty() && other.empty());
+}
 
 bool interval::operator!=(const interval &other) const { return !(*this == other); }
 

--- a/src/walks/node/pivot.hpp
+++ b/src/walks/node/pivot.hpp
@@ -33,7 +33,7 @@ template <int Dim> walk_node<Dim> *walk_node<Dim>::rotate_left(bool set_parent) 
   // merge
   left_->merge();
 
-  // update IDs (TODO: this should be part of merge)
+  // update IDs
   int temp_id = id_;
   id_ = left_->id_;
   left_->id_ = temp_id;

--- a/src/walks/walk_tree.cpp
+++ b/src/walks/walk_tree.cpp
@@ -82,10 +82,11 @@ template <int Dim> walk_node<Dim> &walk_tree<Dim>::find_node(int n) {
 
 template <int Dim> bool walk_tree<Dim>::try_pivot(int n, const transform<Dim> &r) {
   root_->shuffle_up(n);
-  root_->symm_ = root_->symm_ * r; // modify in-place
+  auto root_symm = root_->symm_;
+  root_->symm_ = root_->symm_ * r;
   auto success = !root_->intersect();
   if (!success) {
-    root_->symm_ = root_->symm_ * r.inverse(); // TODO: backup symm_
+    root_->symm_ = root_symm;
   } else {
     root_->merge();
   }
@@ -140,6 +141,8 @@ template <int Dim> bool walk_tree<Dim>::self_avoiding() const {
 }
 
 template <int Dim> void walk_tree<Dim>::export_csv(const std::string &path) const { return to_csv(path, steps()); }
+
+template <int Dim> void walk_tree<Dim>::todot(const std::string &path) const { root_->todot(path); }
 
 /* TEMPLATE INSTANTIATION */
 

--- a/tests/walk_node_test.cpp
+++ b/tests/walk_node_test.cpp
@@ -144,8 +144,7 @@ TEST(RandomWalk, IsNearestNeighbor) {
 TEST(WalkNode, BalancedSteps) {
     auto steps = random_walk<2>(100);
     auto tree = walk_tree<2>(steps);
-    auto root = tree.root();
-    auto result = root->steps();
+    auto result = tree.steps();
     EXPECT_EQ(steps, result);
 }
 
@@ -215,7 +214,7 @@ TEST(WalkNode, RotateRightStepsRand2D) {
 
     auto tree = walk_tree<2>(steps);
     auto root = tree.root();
-    ASSERT_EQ(root->steps(), steps);
+    ASSERT_EQ(tree.steps(), steps);
     EXPECT_EQ(root->rotate_right()->steps(), steps);
 }
 
@@ -225,7 +224,7 @@ TEST(WalkNode, RotateLeftStepsRand2D) {
 
     auto tree = walk_tree<2>(steps);
     auto root = tree.root();
-    ASSERT_EQ(root->steps(), steps);
+    ASSERT_EQ(tree.steps(), steps);
     EXPECT_EQ(root->rotate_left()->steps(), steps);
 }
 


### PR DESCRIPTION
Only thing worth noting is that using a backup symmetry when attempting a pivot (using the slower, in-place method) is marginally faster.