### PR TITLE
Fix walk-tree steps constructor

### DIFF
--- a/src/walks/node/ctors.hpp
+++ b/src/walks/node/ctors.hpp
@@ -54,7 +54,7 @@ walk_node<Dim> *walk_node<Dim>::balanced_rep(std::span<const point<Dim>> steps, 
   auto abs_symm = transform(steps[n - 1], steps[n]);
   auto glob_inv = glob_symm.inverse();
   auto rel_symm = glob_inv * abs_symm;
-  auto rel_end = glob_inv * (steps.back() - steps.front()) + pivot::point<Dim>::unit(0);
+  auto rel_end = glob_inv * (steps.back() - steps.front()) + point<Dim>::unit(0);
   auto rel_box = point<Dim>::unit(0) + glob_inv * (box(steps) - point<Dim>::unit(0));
   int id = start + n - 1;
   walk_node *root = buf ? new (buf + id - 1) walk_node(id, num_sites, rel_symm, rel_box, rel_end)
@@ -65,7 +65,7 @@ walk_node<Dim> *walk_node<Dim>::balanced_rep(std::span<const point<Dim>> steps, 
     root->left_->parent_ = root;
   }
   if (num_sites - n >= 1) {
-    root->right_ = balanced_rep(steps.subspan(n), start + n, rel_symm * glob_symm, buf);
+    root->right_ = balanced_rep(steps.subspan(n), start + n, glob_symm * rel_symm, buf);
     root->right_->parent_ = root;
   }
   return root;

--- a/tests/walk_tree_test.cpp
+++ b/tests/walk_tree_test.cpp
@@ -21,6 +21,36 @@ TEST(WalkTreeInit, Line) {
     }
 }
 
+TEST(WalkTreeInit, FromPoints2D) {
+    // initialize a walk that isn't just a list of points
+    pivot::walk_tree<2> w1(100);
+    for (size_t i = 0; i < 100; ++i) {
+        w1.rand_pivot();
+    }
+
+    // make sure outputs from steps is consistent with steps constructor
+    auto steps1 = w1.steps();
+    pivot::walk_tree<2> w2(steps1);
+    auto steps2 = w2.steps();
+    EXPECT_EQ(steps1.size(), steps2.size());
+    EXPECT_EQ(steps1, steps2);
+}
+
+TEST(WalkTreeInit, FromPoints3D) {
+    // initialize a walk that isn't just a list of points
+    pivot::walk_tree<3> w1(100);
+    for (size_t i = 0; i < 100; ++i) {
+        w1.rand_pivot();
+    }
+
+    // make sure outputs from steps is consistent with steps constructor
+    auto steps1 = w1.steps();
+    pivot::walk_tree<3> w2(steps1);
+    auto steps2 = w2.steps();
+    EXPECT_EQ(steps1.size(), steps2.size());
+    EXPECT_EQ(steps1, steps2);
+}
+
 TEST(WalkTreePivot, PivotLine) {
     auto w = walk_tree<2>(2);
     pivot::transform<2> trans = transform<2>({1, 0}, {-1, 1});


### PR DESCRIPTION
Also includes a test that fails if the subsequent changes to the constructor aren't made. One thing that's not obvious from the test alone is whether it's really the constructor that's at fault or the `steps` method. Noting here that it's the constructor.