### PR TITLE
compare points with explicit for loop

### DIFF
--- a/src/lattice/point.hpp
+++ b/src/lattice/point.hpp
@@ -14,9 +14,18 @@ template <int Dim> point<Dim> point<Dim>::unit(int i) {
 
 template <int Dim> int point<Dim>::operator[](int i) const { return coords_[i]; }
 
-template <int Dim> bool point<Dim>::operator==(const point &p) const { return coords_ == p.coords_; }
+template <int Dim> bool point<Dim>::operator==(const point &p) const {
+  // Faster than using std::equal, at least for small arrays
+  // https://stackoverflow.com/questions/39262496/why-is-stdequal-much-slower-than-a-hand-rolled-loop-for-two-small-stdarray
+  for (int i = 0; i < Dim; ++i) {
+    if (coords_[i] != p.coords_[i]) {
+      return false;
+    }
+  }
+  return true;
+}
 
-template <int Dim> bool point<Dim>::operator!=(const point &p) const { return coords_ != p.coords_; }
+template <int Dim> bool point<Dim>::operator!=(const point &p) const { return !(*this == p); }
 
 template <int Dim> point<Dim> point<Dim>::operator+(const point<Dim> &p) const {
   std::array<int, Dim> sum;


### PR DESCRIPTION
More performant for small arrays, see e.g.

https://stackoverflow.com/questions/39262496/why-is-stdequal-much-slower-than-a-hand-rolled-loop-for-two-small-stdarray

The difference is most noticeable not when running (naive) simulation, but when verifying self-avoidance explicitly (for which I get 2-3x speedup). This isn't that important for now, but I'm planning on using a more optimized hash map for the naive algorithm, for which the difference is noticeable at simulation-time.