### PR TITLE
Don't count the identity transform as a successful pivot

### DIFF
--- a/src/include/lattice.h
+++ b/src/include/lattice.h
@@ -240,6 +240,9 @@ public:
    */
   box<Dim> operator*(const box<Dim> &b) const;
 
+  /** @brief Returns true if the transform is the identity. */
+  bool is_identity() const;
+
   /**
    * @brief Returns the inverse transform.
    *

--- a/src/lattice/transform.hpp
+++ b/src/lattice/transform.hpp
@@ -77,6 +77,15 @@ template <int Dim> box<Dim> transform<Dim>::operator*(const box<Dim> &b) const {
   return box<Dim>(intervals);
 }
 
+template <int Dim> bool transform<Dim>::is_identity() const {
+  for (int i = 0; i < Dim; ++i) {
+    if (perm_[i] != i || signs_[i] != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
 template <int Dim> transform<Dim> transform<Dim>::inverse() const {
   std::array<int, Dim> perm;
   std::array<int, Dim> signs;

--- a/src/walks/walk.cpp
+++ b/src/walks/walk.cpp
@@ -20,6 +20,10 @@ walk<Dim>::walk(int num_steps, std::optional<unsigned int> seed)
 
 template <int Dim>
 std::optional<std::vector<point<Dim>>> walk<Dim>::try_pivot(int step, const transform<Dim> &trans) const {
+  if (trans.is_identity()) {
+    return {};
+  }
+
   std::vector<point<Dim>> new_points(num_steps() - step - 1);
   for (int i = step + 1; i < num_steps(); ++i) {
     auto q = pivot_point(step, i, trans);

--- a/src/walks/walk_tree.cpp
+++ b/src/walks/walk_tree.cpp
@@ -81,6 +81,10 @@ template <int Dim> walk_node<Dim> &walk_tree<Dim>::find_node(int n) {
 /* HIGH-LEVEL FUNCTIONS */
 
 template <int Dim> bool walk_tree<Dim>::try_pivot(int n, const transform<Dim> &r) {
+  if (r.is_identity()) {
+    return false;
+  }
+
   root_->shuffle_up(n);
   auto root_symm = root_->symm_;
   root_->symm_ = root_->symm_ * r;
@@ -95,6 +99,10 @@ template <int Dim> bool walk_tree<Dim>::try_pivot(int n, const transform<Dim> &r
 }
 
 template <int Dim> bool walk_tree<Dim>::try_pivot_fast(int n, const transform<Dim> &t) {
+  if (t.is_identity()) {
+    return false;
+  }
+
   walk_node<Dim> *w = &find_node(n); // TODO: a pointer seems to be needed, but why?
   walk_node<Dim> w_copy(*w);
   auto success = !w_copy.shuffle_intersect(t, w->is_left_child());


### PR DESCRIPTION
It doesn't make sense to count this as a successful pivot, since nothing changes -- the chain doesn't mix. As a side-effect, performance is slightly better since we don't waste time performing identity transforms.